### PR TITLE
Integrate openapi-typescript

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -19,12 +19,17 @@ const cli = async () => {
   const pathToTypes = flags.types;
   const pathToOutput = flags.output;
 
-  const outputString = await main({
+  const { document, types } = await main({
     pathToSpec,
     pathToTypes,
   });
 
-  await fs.writeFile(pathToOutput, outputString, "utf8");
+  const promises = [
+    fs.writeFile(pathToOutput, document, "utf8"),
+    fs.writeFile(pathToTypes, types, "utf8"),
+  ];
+
+  await Promise.all(promises);
 
   console.timeEnd("Measured time");
 };

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -45,6 +45,8 @@ const cli = async () => {
   } catch (err) {
     if (err.code === "ENOENT") {
       await fs.mkdir(pathToOutputDir);
+    } else {
+      throw err;
     }
   }
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -4,7 +4,7 @@ import parser from "yargs-parser";
 import main from "../dist/main.js";
 
 const cli = async () => {
-  console.time("Measured time");
+  console.time("Generated files in");
   const [, , ...args] = process.argv;
 
   const flags = parser(args, {
@@ -31,7 +31,7 @@ const cli = async () => {
 
   await Promise.all(promises);
 
-  console.timeEnd("Measured time");
+  console.timeEnd("Generated files in");
 };
 
 cli();

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -3,6 +3,14 @@ import fs from "node:fs/promises";
 import parser from "yargs-parser";
 import main from "../dist/main.js";
 
+const HELP = `Usage
+  $ openapi-fetch [input] [options]
+
+Options
+  --help                       Display this
+  --output, -o                 Specify path to output directory
+`;
+
 const cli = async () => {
   console.time("Generated files in");
   const [, , ...args] = process.argv;
@@ -13,6 +21,16 @@ const cli = async () => {
       output: ["o"],
     },
   });
+
+  if ("help" in flags) {
+    console.info(HELP);
+    process.exit(0);
+  } else if (!flags._[0] || !flags.output) {
+    console.error(
+      "Missing argument! Both the path to a schema and an output directory must be provided"
+    );
+    process.exit(1);
+  }
 
   const pathToSpec = flags._[0];
   const pathToOutputDir = new URL(

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^10.1.0",
+        "openapi-typescript": "^6.2.0",
         "yargs-parser": "^21.1.1"
       },
       "bin": {
@@ -147,7 +148,6 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
         "run-parallel": "^1.1.9"
@@ -160,7 +160,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
       "engines": {
         "node": ">= 8"
       }
@@ -169,7 +168,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
@@ -461,6 +459,14 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -504,12 +510,22 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-      "dev": true,
       "dependencies": {
         "fill-range": "^7.0.1"
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
       }
     },
     "node_modules/callsites": {
@@ -848,7 +864,6 @@
       "version": "3.2.12",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
       "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
-      "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -864,7 +879,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -888,7 +902,6 @@
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
       "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
-      "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
       }
@@ -909,7 +922,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-      "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -1151,7 +1163,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1160,7 +1171,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -1172,7 +1182,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "engines": {
         "node": ">=0.12.0"
       }
@@ -1280,7 +1289,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
       "engines": {
         "node": ">= 8"
       }
@@ -1289,7 +1297,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
       "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
-      "dev": true,
       "dependencies": {
         "braces": "^3.0.2",
         "picomatch": "^2.3.1"
@@ -1344,6 +1351,33 @@
       "dev": true,
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/openapi-typescript": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/openapi-typescript/-/openapi-typescript-6.2.0.tgz",
+      "integrity": "sha512-d1HF70HCUnU+g9hgX5X3MJ+BMgwX16fzwD6mkyfNqdxXuOTOSkm+O+aaFqLNX13aFbCylz4m2WiVe4viAShxiQ==",
+      "dependencies": {
+        "ansi-colors": "^4.1.3",
+        "fast-glob": "^3.2.12",
+        "js-yaml": "^4.1.0",
+        "supports-color": "^9.3.1",
+        "undici": "^5.20.0",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "openapi-typescript": "bin/cli.js"
+      }
+    },
+    "node_modules/openapi-typescript/node_modules/supports-color": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-9.3.1.tgz",
+      "integrity": "sha512-knBY82pjmnIzK3NifMo3RxEIRD9E0kIzV4BKcyTZ9+9kWgLMxd4PrsTSMoFQUabgRBbF8KOLRDCyKgNV+iK44Q==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/openapi3-ts": {
@@ -1491,7 +1525,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -1536,7 +1569,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1577,7 +1609,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-      "dev": true,
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
@@ -1605,7 +1636,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1669,6 +1699,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -1703,7 +1741,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -1767,6 +1804,17 @@
       },
       "engines": {
         "node": ">=4.2.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
+      "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
+      "dependencies": {
+        "busboy": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=12.18"
       }
     },
     "node_modules/uri-js": {
@@ -1915,7 +1963,6 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
       "requires": {
         "@nodelib/fs.stat": "2.0.5",
         "run-parallel": "^1.1.9"
@@ -1924,14 +1971,12 @@
     "@nodelib/fs.stat": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="
     },
     "@nodelib/fs.walk": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
       "requires": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
@@ -2115,6 +2160,11 @@
         "uri-js": "^4.2.2"
       }
     },
+    "ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="
+    },
     "ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -2152,9 +2202,16 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-      "dev": true,
       "requires": {
         "fill-range": "^7.0.1"
+      }
+    },
+    "busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "requires": {
+        "streamsearch": "^1.1.0"
       }
     },
     "callsites": {
@@ -2405,7 +2462,6 @@
       "version": "3.2.12",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
       "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
-      "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -2418,7 +2474,6 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
           "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-          "dev": true,
           "requires": {
             "is-glob": "^4.0.1"
           }
@@ -2441,7 +2496,6 @@
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
       "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
-      "dev": true,
       "requires": {
         "reusify": "^1.0.4"
       }
@@ -2459,7 +2513,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-      "dev": true,
       "requires": {
         "to-regex-range": "^5.0.1"
       }
@@ -2638,14 +2691,12 @@
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="
     },
     "is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "requires": {
         "is-extglob": "^2.1.1"
       }
@@ -2653,8 +2704,7 @@
     "is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
     },
     "is-path-inside": {
       "version": "3.0.3",
@@ -2736,14 +2786,12 @@
     "merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
     },
     "micromatch": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
       "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
-      "dev": true,
       "requires": {
         "braces": "^3.0.2",
         "picomatch": "^2.3.1"
@@ -2789,6 +2837,26 @@
       "dev": true,
       "requires": {
         "wrappy": "1"
+      }
+    },
+    "openapi-typescript": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/openapi-typescript/-/openapi-typescript-6.2.0.tgz",
+      "integrity": "sha512-d1HF70HCUnU+g9hgX5X3MJ+BMgwX16fzwD6mkyfNqdxXuOTOSkm+O+aaFqLNX13aFbCylz4m2WiVe4viAShxiQ==",
+      "requires": {
+        "ansi-colors": "^4.1.3",
+        "fast-glob": "^3.2.12",
+        "js-yaml": "^4.1.0",
+        "supports-color": "^9.3.1",
+        "undici": "^5.20.0",
+        "yargs-parser": "^21.1.1"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "9.3.1",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-9.3.1.tgz",
+          "integrity": "sha512-knBY82pjmnIzK3NifMo3RxEIRD9E0kIzV4BKcyTZ9+9kWgLMxd4PrsTSMoFQUabgRBbF8KOLRDCyKgNV+iK44Q=="
+        }
       }
     },
     "openapi3-ts": {
@@ -2894,8 +2962,7 @@
     "picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
     },
     "prelude-ls": {
       "version": "1.2.1",
@@ -2918,8 +2985,7 @@
     "queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
     },
     "regexpp": {
       "version": "3.2.0",
@@ -2936,8 +3002,7 @@
     "reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-      "dev": true
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="
     },
     "rimraf": {
       "version": "4.4.0",
@@ -2952,7 +3017,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
       "requires": {
         "queue-microtask": "^1.2.2"
       }
@@ -2987,6 +3051,11 @@
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true
     },
+    "streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="
+    },
     "strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -3012,7 +3081,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "requires": {
         "is-number": "^7.0.0"
       }
@@ -3052,6 +3120,14 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true
+    },
+    "undici": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
+      "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
+      "requires": {
+        "busboy": "^1.6.0"
+      }
     },
     "uri-js": {
       "version": "4.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
         "@typescript-eslint/parser": "^5.54.1",
         "eslint": "^8.36.0",
         "eslint-config-prettier": "^8.7.0",
-        "openapi3-ts": "^3.2.0",
         "prettier": "^2.8.4",
         "rimraf": "^4.4.0",
         "typescript": "^4.9.5"
@@ -1380,15 +1379,6 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
-    "node_modules/openapi3-ts": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-3.2.0.tgz",
-      "integrity": "sha512-/ykNWRV5Qs0Nwq7Pc0nJ78fgILvOT/60OxEmB3v7yQ8a8Bwcm43D4diaYazG/KBn6czA+52XYy931WFLMCUeSg==",
-      "dev": true,
-      "dependencies": {
-        "yaml": "^2.2.1"
-      }
-    },
     "node_modules/optionator": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
@@ -1861,15 +1851,6 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
-    },
-    "node_modules/yaml": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.1.tgz",
-      "integrity": "sha512-e0WHiYql7+9wr4cWMx3TVQrNwejKaEe7/rHNmQmqRjazfOP5W8PB6Jpebb5o6fIapbz9o9+2ipcaTM2ZwDI6lw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 14"
-      }
     },
     "node_modules/yargs-parser": {
       "version": "21.1.1",
@@ -2859,15 +2840,6 @@
         }
       }
     },
-    "openapi3-ts": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-3.2.0.tgz",
-      "integrity": "sha512-/ykNWRV5Qs0Nwq7Pc0nJ78fgILvOT/60OxEmB3v7yQ8a8Bwcm43D4diaYazG/KBn6czA+52XYy931WFLMCUeSg==",
-      "dev": true,
-      "requires": {
-        "yaml": "^2.2.1"
-      }
-    },
     "optionator": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
@@ -3163,12 +3135,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
-    },
-    "yaml": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.1.tgz",
-      "integrity": "sha512-e0WHiYql7+9wr4cWMx3TVQrNwejKaEe7/rHNmQmqRjazfOP5W8PB6Jpebb5o6fIapbz9o9+2ipcaTM2ZwDI6lw==",
       "dev": true
     },
     "yargs-parser": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "scripts": {
     "build": "rimraf dist && tsc",
-    "generate": "node ./bin/cli.js https://petstore3.swagger.io/api/v3/openapi.json --t=./petTypes.js --o=./generated/petFetch.ts",
+    "generate": "node ./bin/cli.js ./generated/github-api.yaml --t=./github-api.js --o=./generated/github-operations.ts",
     "lint": "eslint --max-warnings 0",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
@@ -45,6 +45,7 @@
   "homepage": "https://github.com/marcomuser/openapi-fetch#readme",
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^10.1.0",
+    "openapi-typescript": "^6.2.0",
     "yargs-parser": "^21.1.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "@typescript-eslint/parser": "^5.54.1",
     "eslint": "^8.36.0",
     "eslint-config-prettier": "^8.7.0",
-    "openapi3-ts": "^3.2.0",
     "prettier": "^2.8.4",
     "rimraf": "^4.4.0",
     "typescript": "^4.9.5"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "scripts": {
     "build": "rimraf dist && tsc",
-    "generate": "node ./bin/cli.js ./generated/github-api.yaml --o ./generated/github-operations.ts --t ./generated/github-types.ts",
+    "generate": "node ./bin/cli.js ./generated/github-api.yaml --o ./generated/github/",
     "lint": "eslint --max-warnings 0",
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "scripts": {
     "build": "rimraf dist && tsc",
-    "generate": "node ./bin/cli.js ./generated/github-api.yaml --t=./github-api.js --o=./generated/github-operations.ts",
+    "generate": "node ./bin/cli.js ./generated/github-api.yaml --t=./generated/github-api2.ts --o=./generated/github-operations2.ts",
     "lint": "eslint --max-warnings 0",
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "scripts": {
     "build": "rimraf dist && tsc",
-    "generate": "node ./bin/cli.js ./generated/github-api.yaml --t=./generated/github-api2.ts --o=./generated/github-operations2.ts",
+    "generate": "node ./bin/cli.js ./generated/github-api.yaml --o ./generated/github-operations.ts --t ./generated/github-types.ts",
     "lint": "eslint --max-warnings 0",
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,13 +1,15 @@
 import { transformSpec } from "./transformer/transformSpec.js";
 import { printDocument } from "./printer/printDocument.js";
+import { OTSOptions } from "./utils/types.js";
 
-type TInput = {
-  pathToSpec: string;
-  pathToTypes: string;
-};
-
-export default async function main({ pathToSpec, pathToTypes }: TInput) {
-  const { operations, types } = await transformSpec(pathToSpec);
-  const document = printDocument(operations, pathToTypes);
-  return { document, types };
+export default async function main(
+  pathToSpec: string,
+  openAPITSOptions: OTSOptions = {}
+) {
+  const { operations, typesDoc } = await transformSpec(
+    pathToSpec,
+    openAPITSOptions
+  );
+  const operationsDoc = printDocument(operations);
+  return { operationsDoc, typesDoc };
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { parseSpec } from "./parser/parseSpec.js";
+import { transformSpec } from "./transformer/transformSpec.js";
 import { printDocument } from "./printer/printDocument.js";
 
 type TInput = {
@@ -7,7 +7,7 @@ type TInput = {
 };
 
 export default async function main({ pathToSpec, pathToTypes }: TInput) {
-  const { operations, types } = await parseSpec(pathToSpec);
+  const { operations, types } = await transformSpec(pathToSpec);
   const document = printDocument(operations, pathToTypes);
   return { document, types };
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,7 @@ type TInput = {
 };
 
 export default async function main({ pathToSpec, pathToTypes }: TInput) {
-  const operations = await parseSpec(pathToSpec);
+  const { operations, types } = await parseSpec(pathToSpec);
   const document = printDocument(operations, pathToTypes);
-  return document;
+  return { document, types };
 }

--- a/src/parser/getResWithSortedContentType.ts
+++ b/src/parser/getResWithSortedContentType.ts
@@ -1,7 +1,7 @@
 import { PREFERRED_RES_CONTENT_TYPES } from "../utils/constants.js";
 import type { Response, Responses } from "../utils/types.js";
 
-export const getResWithSortedContentType = (responses: Responses) => {
+export const getResWithSortedContentType = (responses?: Responses) => {
   const resWithSortedContentTypes = new Map<string, string>();
 
   for (const statusCode in responses) {

--- a/src/parser/parseSpec.ts
+++ b/src/parser/parseSpec.ts
@@ -1,9 +1,12 @@
 import { $RefParser } from "@apidevtools/json-schema-ref-parser";
+import openapiTS from "openapi-typescript";
 import type { Document } from "../utils/types.js";
 import { buildOperations } from "./buildOperations.js";
 
 export const parseSpec = async (pathToSpec: string) => {
   const parser = new $RefParser();
   const dereferencedSpec = (await parser.dereference(pathToSpec)) as Document;
-  return buildOperations(dereferencedSpec);
+  const types = await openapiTS(dereferencedSpec);
+  const operations = buildOperations(dereferencedSpec);
+  return { operations, types };
 };

--- a/src/printer/fetchFns/body/printFnBody.ts
+++ b/src/printer/fetchFns/body/printFnBody.ts
@@ -1,4 +1,4 @@
-import type { ExtractedOperation } from "../../../parser/buildOperations.js";
+import type { ExtractedOperation } from "../../../transformer/operations/buildOperations.js";
 import { printOptions } from "./printOptions.js";
 import { printReturn } from "./printReturn.js";
 import { printUrl } from "./printUrl.js";

--- a/src/printer/fetchFns/body/printOptions.ts
+++ b/src/printer/fetchFns/body/printOptions.ts
@@ -1,4 +1,4 @@
-import type { ExtractedOperation } from "../../../parser/buildOperations.js";
+import type { ExtractedOperation } from "../../../transformer/operations/buildOperations.js";
 import { REQ_BODY_CONTENT_TYPE_DICT } from "../../../utils/constants.js";
 
 export const printOptions = ({

--- a/src/printer/fetchFns/body/printReturn.ts
+++ b/src/printer/fetchFns/body/printReturn.ts
@@ -1,4 +1,4 @@
-import type { ExtractedOperation } from "../../../parser/buildOperations.js";
+import type { ExtractedOperation } from "../../../transformer/operations/buildOperations.js";
 import { RES_CONTENT_TYPE_DICT } from "../../../utils/constants.js";
 
 export const printReturn = (operation: ExtractedOperation) => {

--- a/src/printer/fetchFns/body/printReturn.ts
+++ b/src/printer/fetchFns/body/printReturn.ts
@@ -27,10 +27,10 @@ const printSwitchStatement = ({
         return {
           response,
           data: ${getDataValue(
-            responsesWithContentType.get(status) as string
-          )} as operations["${operationId}"]["responses"]["${status}"]["content"]["${responsesWithContentType.get(
-        status
-      )}"],
+            status,
+            responsesWithContentType.get(status) as string,
+            operationId
+          )},
         };
         `;
     }
@@ -41,10 +41,10 @@ const printSwitchStatement = ({
     return {
       response,
       data: ${getDataValue(
-        responsesWithContentType.get("default") as string
-      )} as operations["${operationId}"]["responses"]["default"]["content"]["${responsesWithContentType.get(
-      "default"
-    )}"],
+        "default",
+        responsesWithContentType.get("default") as string,
+        operationId
+      )},
     };
     };
     `;
@@ -60,9 +60,13 @@ const printSwitchStatement = ({
   return switchStatement;
 };
 
-const getDataValue = (preferredContentType: string) => {
+const getDataValue = (
+  status: string,
+  preferredContentType: string,
+  operationId?: string
+) => {
   if (isHandledContentType(preferredContentType)) {
-    return `(await response${RES_CONTENT_TYPE_DICT[preferredContentType]})`;
+    return `(await response${RES_CONTENT_TYPE_DICT[preferredContentType]}) as operations["${operationId}"]["responses"]["${status}"]["content"]["${preferredContentType}"]`;
   }
 
   return "undefined";

--- a/src/printer/fetchFns/body/printUrl.ts
+++ b/src/printer/fetchFns/body/printUrl.ts
@@ -28,6 +28,6 @@ const searchParams = `const searchParams = new URLSearchParams();
     } else if (typeof value === "object") {
       searchParams.set(key, JSON.stringify(value));
     } else {
-      searchParams.set(key, value);
+      searchParams.set(key, String(value));
     }
   }`;

--- a/src/printer/fetchFns/body/printUrl.ts
+++ b/src/printer/fetchFns/body/printUrl.ts
@@ -1,4 +1,4 @@
-import type { ExtractedOperation } from "../../../parser/buildOperations.js";
+import type { ExtractedOperation } from "../../../transformer/operations/buildOperations.js";
 
 export const printUrl = ({ path, parameterTypes }: ExtractedOperation) => {
   const replacedPath = replacePathParams(path);

--- a/src/printer/fetchFns/header/printFnHeader.ts
+++ b/src/printer/fetchFns/header/printFnHeader.ts
@@ -20,7 +20,7 @@ export const printFnHeader = ({
     config: ExtRequestInit`
     : `config: ExtRequestInit`;
 
-  return `export const ${operationId} = async(
+  return `export const ${getSanitizedFnName(operationId as string)} = async(
     ${args}
   ) => {`;
 };
@@ -35,4 +35,20 @@ const getParams = (parametersTypeRef: string, reqBodyTypeRef: string) => {
   } else {
     return "";
   }
+};
+
+const getSanitizedFnName = (operationId: string) => {
+  // Replace non-alphanumeric characters with spaces
+  const sanitized = operationId.replaceAll(/\W/g, " ");
+
+  // Convert to camelCase and remove any leading or trailing spaces
+  return sanitized
+    .split(" ")
+    .map((word, index) =>
+      index === 0
+        ? word.toLowerCase()
+        : word.charAt(0).toUpperCase() + word.slice(1).toLowerCase()
+    )
+    .join("")
+    .trim();
 };

--- a/src/printer/fetchFns/header/printFnHeader.ts
+++ b/src/printer/fetchFns/header/printFnHeader.ts
@@ -20,7 +20,7 @@ export const printFnHeader = ({
     config: ExtRequestInit`
     : `config: ExtRequestInit`;
 
-  return `export const ${getSanitizedFnName(operationId as string)} = async(
+  return `export const ${getSanitizedFnName(operationId as string)} = async (
     ${args}
   ) => {`;
 };

--- a/src/printer/fetchFns/header/printFnHeader.ts
+++ b/src/printer/fetchFns/header/printFnHeader.ts
@@ -1,4 +1,4 @@
-import type { ExtractedOperation } from "../../../parser/buildOperations.js";
+import type { ExtractedOperation } from "../../../transformer/operations/buildOperations.js";
 
 export const printFnHeader = ({
   operationId,

--- a/src/printer/fetchFns/printFetchFns.ts
+++ b/src/printer/fetchFns/printFetchFns.ts
@@ -1,7 +1,7 @@
 import type {
   ExtractedOperations,
   ExtractedOperation,
-} from "../../parser/buildOperations.js";
+} from "../../transformer/operations/buildOperations.js";
 import { printFnBody } from "./body/printFnBody.js";
 import { printFnHeader } from "./header/printFnHeader.js";
 

--- a/src/printer/header/printImports.ts
+++ b/src/printer/header/printImports.ts
@@ -1,2 +1,2 @@
-export const printImports = (pathToTypes: string) =>
-  `import type { operations } from "${pathToTypes}"`;
+export const printImports = () =>
+  `import type { operations } from "./types.js"`;

--- a/src/printer/printDocument.ts
+++ b/src/printer/printDocument.ts
@@ -1,4 +1,4 @@
-import { ExtractedOperations } from "../parser/buildOperations.js";
+import { ExtractedOperations } from "../transformer/operations/buildOperations.js";
 import { printFetchFns } from "./fetchFns/printFetchFns.js";
 import { printComment } from "./header/printComment.js";
 import { printImports } from "./header/printImports.js";

--- a/src/printer/printDocument.ts
+++ b/src/printer/printDocument.ts
@@ -5,11 +5,10 @@ import { printImports } from "./header/printImports.js";
 import { printSharedTypes } from "./header/printSharedTypes.js";
 
 export const printDocument = (
-  operations: ExtractedOperations,
-  pathToTypes: string
+  operations: ExtractedOperations
 ) => `${printComment()}
   
-  ${printImports(pathToTypes)}
+  ${printImports()}
 
   ${printSharedTypes()}
 

--- a/src/transformer/operations/buildOperations.ts
+++ b/src/transformer/operations/buildOperations.ts
@@ -1,10 +1,10 @@
-import { HTTP_VERBS } from "../utils/constants.js";
+import { HTTP_VERBS } from "../../utils/constants.js";
 import type {
   Document,
   Operation,
   Parameter,
   RequestBody,
-} from "../utils/types.js";
+} from "../../utils/types.js";
 import { getParameterTypes } from "./getParameterTypes.js";
 import { getReqSortedContentType } from "./getReqSortedContentType.js";
 import { getResWithSortedContentType } from "./getResWithSortedContentType.js";

--- a/src/transformer/operations/getParameterTypes.ts
+++ b/src/transformer/operations/getParameterTypes.ts
@@ -1,4 +1,4 @@
-import type { Parameter } from "../utils/types.js";
+import type { Parameter } from "../../utils/types.js";
 
 export const getParameterTypes = (parameters?: Parameter[]) => {
   const types: Record<Parameter["in"], boolean> = {

--- a/src/transformer/operations/getReqSortedContentType.ts
+++ b/src/transformer/operations/getReqSortedContentType.ts
@@ -1,5 +1,5 @@
-import { PREFERRED_REQ_CONTENT_TYPES } from "../utils/constants.js";
-import type { RequestBody } from "../utils/types.js";
+import { PREFERRED_REQ_CONTENT_TYPES } from "../../utils/constants.js";
+import type { RequestBody } from "../../utils/types.js";
 
 export const getReqSortedContentType = (requestBody?: RequestBody) => {
   if (!requestBody?.content) {

--- a/src/transformer/operations/getResWithSortedContentType.ts
+++ b/src/transformer/operations/getResWithSortedContentType.ts
@@ -1,5 +1,5 @@
-import { PREFERRED_RES_CONTENT_TYPES } from "../utils/constants.js";
-import type { Response, Responses } from "../utils/types.js";
+import { PREFERRED_RES_CONTENT_TYPES } from "../../utils/constants.js";
+import type { Response, Responses } from "../../utils/types.js";
 
 export const getResWithSortedContentType = (responses?: Responses) => {
   const resWithSortedContentTypes = new Map<string, string>();

--- a/src/transformer/transformSpec.ts
+++ b/src/transformer/transformSpec.ts
@@ -1,12 +1,15 @@
 import { $RefParser } from "@apidevtools/json-schema-ref-parser";
 import openapiTS from "openapi-typescript";
-import type { Document } from "../utils/types.js";
+import type { Document, OTSOptions } from "../utils/types.js";
 import { buildOperations } from "./operations/buildOperations.js";
 
-export const transformSpec = async (pathToSpec: string) => {
+export const transformSpec = async (
+  pathToSpec: string,
+  openAPITSOptions: OTSOptions
+) => {
   const parser = new $RefParser();
   const dereferencedSpec = (await parser.dereference(pathToSpec)) as Document;
-  const types = await openapiTS(dereferencedSpec);
+  const typesDoc = await openapiTS(dereferencedSpec, openAPITSOptions);
   const operations = buildOperations(dereferencedSpec);
-  return { operations, types };
+  return { operations, typesDoc };
 };

--- a/src/transformer/transformSpec.ts
+++ b/src/transformer/transformSpec.ts
@@ -1,9 +1,9 @@
 import { $RefParser } from "@apidevtools/json-schema-ref-parser";
 import openapiTS from "openapi-typescript";
 import type { Document } from "../utils/types.js";
-import { buildOperations } from "./buildOperations.js";
+import { buildOperations } from "./operations/buildOperations.js";
 
-export const parseSpec = async (pathToSpec: string) => {
+export const transformSpec = async (pathToSpec: string) => {
   const parser = new $RefParser();
   const dereferencedSpec = (await parser.dereference(pathToSpec)) as Document;
   const types = await openapiTS(dereferencedSpec);

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -24,9 +24,10 @@ export const REQ_BODY_CONTENT_TYPE_DICT = {
   "multipart/form-data": "new FormData(params.requestBody)",
 } as const;
 
-export const PREFERRED_RES_CONTENT_TYPES = ["application/json"];
+export const PREFERRED_RES_CONTENT_TYPES = ["application/json", "text/plain"];
 
 export const RES_CONTENT_TYPE_DICT = {
   "application/json": ".json()",
+  "text/plain": ".text()",
   "text/html": ".text()",
 } as const;

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,13 +1,13 @@
 import {
-  OpenAPIObject,
+  OpenAPI3,
   OperationObject,
   ParameterObject,
   RequestBodyObject,
   ResponsesObject,
   ResponseObject,
-} from "openapi3-ts";
+} from "openapi-typescript";
 
-export type Document = OpenAPIObject;
+export type Document = OpenAPI3;
 
 export type Operation = OperationObject;
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -5,6 +5,7 @@ import {
   RequestBodyObject,
   ResponsesObject,
   ResponseObject,
+  OpenAPITSOptions,
 } from "openapi-typescript";
 
 export type Document = OpenAPI3;
@@ -18,3 +19,5 @@ export type RequestBody = RequestBodyObject;
 export type Responses = ResponsesObject;
 
 export type Response = ResponseObject;
+
+export type OTSOptions = Partial<OpenAPITSOptions>;


### PR DESCRIPTION
After testing the existing generator on several APIs (mainly Github), I decided it's better to integrate openapi-typescript as an internal dependency than to work with its output only. The reason is that openapi-typescript doesn't dereference schemas which, however, is necessary in order to generate complete fetch functions.