### PR TITLE
Omit request body content-types when applicable

### DIFF
--- a/src/printer/fetchFns/body/printHeaders.ts
+++ b/src/printer/fetchFns/body/printHeaders.ts
@@ -1,4 +1,5 @@
 import type { TransformedOperation } from "../../../transformer/operations/buildOperations.js";
+import { OMITTABLE_REQ_CONTENT_TYPES } from "../../../utils/constants.js";
 
 export const printHeaders = ({
   reqContentType,
@@ -14,15 +15,10 @@ const getHeaders = (
   reqContentType: TransformedOperation["reqContentType"],
   responsesWithContentType: TransformedOperation["responsesWithContentType"]
 ) => {
-  const OMITTABLE_CONTENT_TYPES = {
-    "multipart/form-data": true,
-    "application/x-www-form-urlencoded": true,
-  } as const;
-
   const hasNonOmittableReqContentType = Boolean(
     reqContentType &&
-      !OMITTABLE_CONTENT_TYPES[
-        reqContentType as keyof typeof OMITTABLE_CONTENT_TYPES
+      !OMITTABLE_REQ_CONTENT_TYPES[
+        reqContentType as keyof typeof OMITTABLE_REQ_CONTENT_TYPES
       ]
   );
 

--- a/src/printer/fetchFns/body/printHeaders.ts
+++ b/src/printer/fetchFns/body/printHeaders.ts
@@ -14,25 +14,37 @@ const getHeaders = (
   reqContentType: TransformedOperation["reqContentType"],
   responsesWithContentType: TransformedOperation["responsesWithContentType"]
 ) => {
-  if (reqContentType && responsesWithContentType.size) {
+  const OMITTABLE_CONTENT_TYPES = {
+    "multipart/form-data": true,
+    "application/x-www-form-urlencoded": true,
+  } as const;
+
+  const hasNonOmittableReqContentType = Boolean(
+    reqContentType &&
+      !OMITTABLE_CONTENT_TYPES[
+        reqContentType as keyof typeof OMITTABLE_CONTENT_TYPES
+      ]
+  );
+
+  if (hasNonOmittableReqContentType && responsesWithContentType.size) {
     return `new Headers({
-  "Accept": "${getAcceptHeaders(responsesWithContentType)}",
+  "Accept": "${getAcceptValue(responsesWithContentType)}",
   "Content-Type": "${reqContentType}",
 })`;
-  } else if (reqContentType && !responsesWithContentType.size) {
+  } else if (hasNonOmittableReqContentType && !responsesWithContentType.size) {
     return `new Headers({
   "Content-Type": "${reqContentType}",
 })`;
-  } else if (!reqContentType && responsesWithContentType.size) {
+  } else if (!hasNonOmittableReqContentType && responsesWithContentType.size) {
     return `new Headers({
-  "Accept": "${getAcceptHeaders(responsesWithContentType)}",
+  "Accept": "${getAcceptValue(responsesWithContentType)}",
 })`;
   } else {
     return "new Headers()";
   }
 };
 
-const getAcceptHeaders = (
+const getAcceptValue = (
   responsesWithContentType: TransformedOperation["responsesWithContentType"]
 ) => {
   const contentTypesSet = new Set<string>();

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -9,6 +9,11 @@ export const HTTP_VERBS = {
   patch: true,
 } as const;
 
+export const OMITTABLE_REQ_CONTENT_TYPES = {
+  "multipart/form-data": true,
+  "application/x-www-form-urlencoded": true,
+} as const;
+
 export const PREFERRED_REQ_CONTENT_TYPES = [
   "application/json",
   "multipart/form-data",


### PR DESCRIPTION
The content-type in the headers will be set automatically when FormData or URLSearchParams is used to encode the requestBody.